### PR TITLE
Fixes for PgSQL loading scripts

### DIFF
--- a/postgres/load.py
+++ b/postgres/load.py
@@ -1,33 +1,78 @@
-import psycopg2
-import sys
-import os
+#!/usr/bin/env python3
 
-def vacuum(con):
+import argparse
+import os
+import psycopg2
+
+
+def vacuum(con, pg_con):
     old_isolation_level = con.isolation_level
     pg_con.set_isolation_level(psycopg2.extensions.ISOLATION_LEVEL_AUTOCOMMIT)
     pg_con.cursor().execute("VACUUM FULL")
     pg_con.set_isolation_level(old_isolation_level)
 
-print("Running Postgres / psycopg2")
-
-print("Datagen / load initial data set using SQL")
-
-pg_con = psycopg2.connect(database="ldbcsnb", host="localhost", user="postgres", password="mysecretpassword",  port=5432)
-con = pg_con.cursor()
 
 def load_script(filename):
     with open(filename, "r") as f:
         return f.read()
 
-con.execute(load_script("ddl/schema.sql"))
-con.execute(load_script("ddl/snb-load.sql"))
-pg_con.commit()
 
-con.execute(load_script("ddl/schema_constraints.sql"))
-con.execute(load_script("ddl/schema_foreign_keys.sql"))
-pg_con.commit()
+def main(argv=None):
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--db",
+        default=os.environ.get("POSTGRES_DATABASE", "ldbcsnb"),
+        help="PostgreSQL database",
+    )
+    parser.add_argument(
+        "--host", default="localhost", help="PostgreSQL host",
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=int(os.environ.get("POSTGRES_PORT", 5432)),
+        help="PostgreSQL port",
+    )
+    parser.add_argument(
+        "--user",
+        default=os.environ.get("POSTGRES_USER", "postgres"),
+        help="PostgreSQL user name",
+    )
+    parser.add_argument(
+        "--password",
+        default=os.environ.get("POSTGRES_PASSWORD", "mysecretpassword"),
+        help="PostgreSQL user password",
+    )
+    options = parser.parse_args(argv)
 
-print("Vacuuming")
-vacuum(pg_con)
+    print("Running Postgres / psycopg2")
 
-print("Loaded initial snapshot")
+    print("Datagen / load initial data set using SQL")
+
+    pg_con = psycopg2.connect(
+        database=options.db,
+        host=options.host,
+        user=options.user,
+        password=options.password,
+        port=options.port,
+    )
+    try:
+        with pg_con.cursor() as con:
+            con.execute(load_script("ddl/schema.sql"))
+            con.execute(load_script("ddl/snb-load.sql"))
+            pg_con.commit()
+
+            con.execute(load_script("ddl/schema_constraints.sql"))
+            con.execute(load_script("ddl/schema_foreign_keys.sql"))
+            pg_con.commit()
+
+            print("Vacuuming")
+            vacuum(pg_con)
+    finally:
+        pg_con.close()
+
+    print("Loaded initial snapshot")
+
+
+if __name__ == "__main__":
+    main()

--- a/postgres/load.py
+++ b/postgres/load.py
@@ -25,7 +25,9 @@ def main(argv=None):
         help="PostgreSQL database",
     )
     parser.add_argument(
-        "--host", default="localhost", help="PostgreSQL host",
+        "--host",
+        default=os.environ.get("POSTGRES_HOST", "localhost"),
+        help="PostgreSQL host",
     )
     parser.add_argument(
         "--port",

--- a/postgres/load.py
+++ b/postgres/load.py
@@ -5,8 +5,8 @@ import os
 import psycopg2
 
 
-def vacuum(con, pg_con):
-    old_isolation_level = con.isolation_level
+def vacuum(pg_con):
+    old_isolation_level = pg_con.isolation_level
     pg_con.set_isolation_level(psycopg2.extensions.ISOLATION_LEVEL_AUTOCOMMIT)
     pg_con.cursor().execute("VACUUM FULL")
     pg_con.set_isolation_level(old_isolation_level)

--- a/postgres/scripts/load.sh
+++ b/postgres/scripts/load.sh
@@ -6,6 +6,8 @@ set -o pipefail
 cd "$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 cd ..
 
+. scripts/vars.sh
+
 POSTGRES_FORCE_REGENERATE=${POSTGRES_FORCE_REGENERATE:-no}
 
 # we regenerate PostgreSQL-specific CSV files for comments, if either

--- a/postgres/scripts/start.sh
+++ b/postgres/scripts/start.sh
@@ -19,29 +19,37 @@ echo "POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}"
 echo "POSTGRES_DATABASE: ${POSTGRES_DATABASE}"
 echo "POSTGRES_SHARED_MEMORY: ${POSTGRES_SHARED_MEMORY}"
 echo "POSTGRES_USER: ${POSTGRES_USER}"
+echo "POSTGRES_PORT: ${POSTGRES_PORT}"
 echo "POSTGRES_DATABASE_DIR (on the host machine):"
 echo "  ${POSTGRES_DATABASE_DIR}"
 echo "POSTGRES_CSV_DIR (on the host machine):"
 echo "  ${POSTGRES_CSV_DIR}"
 echo "==============================================================================="
 
-if [ ! -d ${POSTGRES_CSV_DIR} ]; then
+if [ ! -d "${POSTGRES_CSV_DIR}" ]; then
     echo "Directory ${POSTGRES_CSV_DIR} does not exist."
     exit 1
 fi
 
 docker run --rm \
-    --publish=5432:5432 \
+    --publish=${POSTGRES_PORT}:5432 \
     --name ${POSTGRES_CONTAINER_NAME} \
+    --env POSTGRES_DATABASE=${POSTGRES_DATABASE} \
+    --env POSTGRES_USER=${POSTGRES_USER} \
     --env POSTGRES_PASSWORD=${POSTGRES_PASSWORD} \
     --volume=${POSTGRES_CSV_DIR}:/data \
     --volume=${POSTGRES_DATABASE_DIR}:/var/lib/postgresql/data \
     --detach \
     --shm-size=${POSTGRES_SHARED_MEMORY} \
-    postgres:${POSTGRES_VERSION}
+    postgres:${POSTGRES_VERSION} || exit 1
 
 echo -n "Waiting for the database to start ."
 until python3 scripts/test-db-connection.py > /dev/null 2>&1; do
+    docker ps | grep ${POSTGRES_CONTAINER_NAME} 1>/dev/null 2>&1 || (
+        echo
+        echo "Container lost."
+        exit 1
+    )
     echo -n " ."
     sleep 1
 done

--- a/postgres/scripts/test-db-connection.py
+++ b/postgres/scripts/test-db-connection.py
@@ -1,3 +1,12 @@
+#!/usr/bin/env python3
+
+import os
 import psycopg2
 
-con = psycopg2.connect(host="localhost", user="postgres", password="mysecretpassword", port=5432)
+con = psycopg2.connect(
+    host="localhost",
+    user=os.environ.get("POSTGRES_USER", "postgres"),
+    password=os.environ.get("POSTGRES_PASSWORD", "mysecretpassword"),
+    port=int(os.environ.get("POSTGRES_PORT", 5432)),
+)
+con.close()

--- a/postgres/scripts/test-db-connection.py
+++ b/postgres/scripts/test-db-connection.py
@@ -4,7 +4,7 @@ import os
 import psycopg2
 
 con = psycopg2.connect(
-    host="localhost",
+    host=os.environ.get("POSTGRES_HOST", "localhost"),
     user=os.environ.get("POSTGRES_USER", "postgres"),
     password=os.environ.get("POSTGRES_PASSWORD", "mysecretpassword"),
     port=int(os.environ.get("POSTGRES_PORT", 5432)),

--- a/postgres/scripts/vars.sh
+++ b/postgres/scripts/vars.sh
@@ -10,5 +10,6 @@ export POSTGRES_DATABASE=ldbcsnb
 export POSTGRES_SHARED_MEMORY=8g
 export POSTGRES_USER=postgres
 export POSTGRES_DATABASE_DIR=`pwd`/scratch/data
+export POSTGRES_PORT=5432
 
 popd


### PR DESCRIPTION
I had some issues with the PgSQL loading script, here are some small changes:

- Script now allows to have a custom Docker published port (5432 can already be bound)
- PgSQL user and DB name were not given to the container
- For some reason, the container can fail to start: it is now checked while waiting for PgSQL to start
- load.py was using constants instead of the environment variables