### PR TITLE
Emphasize that frequencies/interleave values are different between SFs

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,3 +99,7 @@ ldbc.snb.datagen.serializer.personSerializer:ldbc.snb.datagen.serializer.snb.int
 ldbc.snb.datagen.serializer.invariantSerializer:ldbc.snb.datagen.serializer.snb.interactive.<SerializerType>InvariantSerializer
 ldbc.snb.datagen.serializer.personActivitySerializer:ldbc.snb.datagen.serializer.snb.interactive.<SerializerType>PersonActivitySerializer
 ```
+
+:warning: *Each scale factor has a different configuration. For benchmark runs, make sure you use the correct update interleave value and query frequencies provided in the [`sf-properties` directory](../sf-properties)*
+
+:warning: *Note that the default workload contains updates which are persisted in the database. Therefore, the database needs to be re-loaded between steps – otherwise repeated updates would insert duplicate entries.*

--- a/cypher/README.md
+++ b/cypher/README.md
@@ -87,4 +87,6 @@ driver/validate.sh
 driver/benchmark.sh
 ```
 
-:warning: *Note that if the default workload contains updates which are persisted in the database. Therefore, the database needs to be re-loaded between steps – otherwise repeated updates would insert duplicate entries.*
+:warning: *Each scale factor has a different configuration. For benchmark runs, make sure you use the correct update interleave value and query frequencies provided in the [`sf-properties` directory](../sf-properties)*
+
+:warning: *Note that the default workload contains updates which are persisted in the database. Therefore, the database needs to be re-loaded between steps – otherwise repeated updates would insert duplicate entries.*

--- a/cypher/driver/benchmark.properties
+++ b/cypher/driver/benchmark.properties
@@ -21,35 +21,37 @@ ignore_scheduled_start_times=true
 
 workload=com.ldbc.driver.workloads.ldbc.snb.interactive.LdbcSnbInteractiveWorkload
 db=com.ldbc.impls.workloads.ldbc.snb.cypher.interactive.CypherInteractiveDb
+
+warmup=100
 operation_count=250
-ldbc.snb.interactive.parameters_dir=test-data/substitution_parameters/
+
 ldbc.snb.interactive.updates_dir=test-data/update_streams/
+ldbc.snb.interactive.parameters_dir=test-data/substitution_parameters/
 ldbc.snb.interactive.short_read_dissipation=0.2
+
 ## The ldbc.snb.interactive.update_interleave driver parameter must come from the
 ## updateStream.properties file, which is created by the data generator. 
 ## This parameter should NEVER be set manually. 
-ldbc.snb.interactive.update_interleave=4477
-
-warmup=100
+ldbc.snb.interactive.update_interleave=895969
 
 ## frequency of read queries (number of update queries per one read query)
 ## Make sure that the frequencies are those for the selected scale factor
 ## as found on section B.1 "Scale Factor Statistics for the Interactive workload"
 ## at https://ldbcouncil.org/ldbc_snb_docs/ldbc-snb-specification.pdf
-ldbc.snb.interactive.LdbcQuery1_freq=26
-ldbc.snb.interactive.LdbcQuery2_freq=37
-ldbc.snb.interactive.LdbcQuery3_freq=69
-ldbc.snb.interactive.LdbcQuery4_freq=36
-ldbc.snb.interactive.LdbcQuery5_freq=57
-ldbc.snb.interactive.LdbcQuery6_freq=129
-ldbc.snb.interactive.LdbcQuery7_freq=87
-ldbc.snb.interactive.LdbcQuery8_freq=45
-ldbc.snb.interactive.LdbcQuery9_freq=157
-ldbc.snb.interactive.LdbcQuery10_freq=30
-ldbc.snb.interactive.LdbcQuery11_freq=16
-ldbc.snb.interactive.LdbcQuery12_freq=44
-ldbc.snb.interactive.LdbcQuery13_freq=19
-ldbc.snb.interactive.LdbcQuery14_freq=49
+ldbc.snb.interactive.LdbcQuery1_freq=1
+ldbc.snb.interactive.LdbcQuery2_freq=1
+ldbc.snb.interactive.LdbcQuery3_freq=1
+ldbc.snb.interactive.LdbcQuery4_freq=1
+ldbc.snb.interactive.LdbcQuery5_freq=1
+ldbc.snb.interactive.LdbcQuery6_freq=1
+ldbc.snb.interactive.LdbcQuery7_freq=1
+ldbc.snb.interactive.LdbcQuery8_freq=1
+ldbc.snb.interactive.LdbcQuery9_freq=1
+ldbc.snb.interactive.LdbcQuery10_freq=1
+ldbc.snb.interactive.LdbcQuery11_freq=1
+ldbc.snb.interactive.LdbcQuery12_freq=1
+ldbc.snb.interactive.LdbcQuery13_freq=1
+ldbc.snb.interactive.LdbcQuery14_freq=1
 
 # *** For debugging purposes ***
 

--- a/cypher/driver/create-validation-parameters.properties
+++ b/cypher/driver/create-validation-parameters.properties
@@ -21,29 +21,31 @@ ignore_scheduled_start_times=false
 
 workload=com.ldbc.driver.workloads.ldbc.snb.interactive.LdbcSnbInteractiveWorkload
 db=com.ldbc.impls.workloads.ldbc.snb.cypher.interactive.CypherInteractiveDb
-operation_count=10000
-ldbc.snb.interactive.parameters_dir=test-data/substitution_parameters/
-ldbc.snb.interactive.updates_dir=test-data/update_streams/
-ldbc.snb.interactive.short_read_dissipation=0.2
-ldbc.snb.interactive.update_interleave=49274
 
+operation_count=10000
 create_validation_parameters=validation_params.csv|100
 
+ldbc.snb.interactive.updates_dir=test-data/update_streams/
+ldbc.snb.interactive.parameters_dir=test-data/substitution_parameters/
+ldbc.snb.interactive.short_read_dissipation=0.2
+
+ldbc.snb.interactive.update_interleave=895969
+
 ## frequency of read queries (number of update queries per one read query)
-ldbc.snb.interactive.LdbcQuery1_freq=26
-ldbc.snb.interactive.LdbcQuery2_freq=37
-ldbc.snb.interactive.LdbcQuery3_freq=69
-ldbc.snb.interactive.LdbcQuery4_freq=36
-ldbc.snb.interactive.LdbcQuery5_freq=57
-ldbc.snb.interactive.LdbcQuery6_freq=129
-ldbc.snb.interactive.LdbcQuery7_freq=87
-ldbc.snb.interactive.LdbcQuery8_freq=45
-ldbc.snb.interactive.LdbcQuery9_freq=157
-ldbc.snb.interactive.LdbcQuery10_freq=30
-ldbc.snb.interactive.LdbcQuery11_freq=16
-ldbc.snb.interactive.LdbcQuery12_freq=44
-ldbc.snb.interactive.LdbcQuery13_freq=19
-ldbc.snb.interactive.LdbcQuery14_freq=49
+ldbc.snb.interactive.LdbcQuery1_freq=1
+ldbc.snb.interactive.LdbcQuery2_freq=1
+ldbc.snb.interactive.LdbcQuery3_freq=1
+ldbc.snb.interactive.LdbcQuery4_freq=1
+ldbc.snb.interactive.LdbcQuery5_freq=1
+ldbc.snb.interactive.LdbcQuery6_freq=1
+ldbc.snb.interactive.LdbcQuery7_freq=1
+ldbc.snb.interactive.LdbcQuery8_freq=1
+ldbc.snb.interactive.LdbcQuery9_freq=1
+ldbc.snb.interactive.LdbcQuery10_freq=1
+ldbc.snb.interactive.LdbcQuery11_freq=1
+ldbc.snb.interactive.LdbcQuery12_freq=1
+ldbc.snb.interactive.LdbcQuery13_freq=1
+ldbc.snb.interactive.LdbcQuery14_freq=1
 
 # *** For debugging purposes ***
 

--- a/cypher/driver/validate.properties
+++ b/cypher/driver/validate.properties
@@ -21,13 +21,15 @@ ignore_scheduled_start_times=false
 
 workload=com.ldbc.driver.workloads.ldbc.snb.interactive.LdbcSnbInteractiveWorkload
 db=com.ldbc.impls.workloads.ldbc.snb.cypher.interactive.CypherInteractiveDb
+
 operation_count=10000
 
 validate_workload=true
 validate_database=validation_params.csv
 ldbc.snb.interactive.parameters_dir=test-data/substitution_parameters/
 ldbc.snb.interactive.short_read_dissipation=0.2
-ldbc.snb.interactive.update_interleave=49274
+
+ldbc.snb.interactive.update_interleave=895969
 
 ldbc.snb.interactive.LdbcQuery1_freq=1
 ldbc.snb.interactive.LdbcQuery2_freq=1

--- a/postgres/README.md
+++ b/postgres/README.md
@@ -57,4 +57,6 @@ ldbc.snb.datagen.serializer.staticSerializer:ldbc.snb.datagen.serializer.snb.csv
     driver/benchmark.sh
     ```
 
-:warning: *Note that if the default workload contains updates which are persisted in the database. Therefore, the database needs to be re-loaded between steps – otherwise repeated updates would insert duplicate entries.*
+:warning: *Each scale factor has a different configuration. For benchmark runs, make sure you use the correct update interleave value and query frequencies provided in the [`sf-properties` directory](../sf-properties)*
+
+:warning: *Note that the default workload contains updates which are persisted in the database. Therefore, the database needs to be re-loaded between steps – otherwise repeated updates would insert duplicate entries.*

--- a/postgres/driver/benchmark.properties
+++ b/postgres/driver/benchmark.properties
@@ -23,35 +23,37 @@ ignore_scheduled_start_times=true
 
 workload=com.ldbc.driver.workloads.ldbc.snb.interactive.LdbcSnbInteractiveWorkload
 db=com.ldbc.impls.workloads.ldbc.snb.postgres.interactive.PostgresInteractiveDb
+
+warmup=100
 operation_count=250
+
 ldbc.snb.interactive.parameters_dir=test-data/substitution_parameters/
 ldbc.snb.interactive.updates_dir=test-data/update_streams/
 ldbc.snb.interactive.short_read_dissipation=0.2
+
 ## The ldbc.snb.interactive.update_interleave driver parameter must come from the
 ## updateStream.properties file, which is created by the data generator. 
 ## This parameter should NEVER be set manually. 
-ldbc.snb.interactive.update_interleave=4477
-
-warmup=100
+ldbc.snb.interactive.update_interleave=895969
 
 ## frequency of read queries (number of update queries per one read query)
 ## Make sure that the frequencies are those for the selected scale factor
 ## as found on section B.1 "Scale Factor Statistics for the Interactive workload"
 ## at https://ldbcouncil.org/ldbc_snb_docs/ldbc-snb-specification.pdf
-ldbc.snb.interactive.LdbcQuery1_freq=26
-ldbc.snb.interactive.LdbcQuery2_freq=37
-ldbc.snb.interactive.LdbcQuery3_freq=69
-ldbc.snb.interactive.LdbcQuery4_freq=36
-ldbc.snb.interactive.LdbcQuery5_freq=57
-ldbc.snb.interactive.LdbcQuery6_freq=129
-ldbc.snb.interactive.LdbcQuery7_freq=87
-ldbc.snb.interactive.LdbcQuery8_freq=45
-ldbc.snb.interactive.LdbcQuery9_freq=157
-ldbc.snb.interactive.LdbcQuery10_freq=30
-ldbc.snb.interactive.LdbcQuery11_freq=16
-ldbc.snb.interactive.LdbcQuery12_freq=44
-ldbc.snb.interactive.LdbcQuery13_freq=19
-ldbc.snb.interactive.LdbcQuery14_freq=49
+ldbc.snb.interactive.LdbcQuery1_freq=1
+ldbc.snb.interactive.LdbcQuery2_freq=1
+ldbc.snb.interactive.LdbcQuery3_freq=1
+ldbc.snb.interactive.LdbcQuery4_freq=1
+ldbc.snb.interactive.LdbcQuery5_freq=1
+ldbc.snb.interactive.LdbcQuery6_freq=1
+ldbc.snb.interactive.LdbcQuery7_freq=1
+ldbc.snb.interactive.LdbcQuery8_freq=1
+ldbc.snb.interactive.LdbcQuery9_freq=1
+ldbc.snb.interactive.LdbcQuery10_freq=1
+ldbc.snb.interactive.LdbcQuery11_freq=1
+ldbc.snb.interactive.LdbcQuery12_freq=1
+ldbc.snb.interactive.LdbcQuery13_freq=1
+ldbc.snb.interactive.LdbcQuery14_freq=1
 
 # *** For debugging purposes ***
 

--- a/postgres/driver/create-validation-parameters.properties
+++ b/postgres/driver/create-validation-parameters.properties
@@ -23,13 +23,14 @@ ignore_scheduled_start_times=false
 
 workload=com.ldbc.driver.workloads.ldbc.snb.interactive.LdbcSnbInteractiveWorkload
 db=com.ldbc.impls.workloads.ldbc.snb.postgres.interactive.PostgresInteractiveDb
-operation_count=10000
-ldbc.snb.interactive.parameters_dir=test-data/substitution_parameters/
-ldbc.snb.interactive.updates_dir=test-data/update_streams/
-ldbc.snb.interactive.short_read_dissipation=0.2
-ldbc.snb.interactive.update_interleave=49274
 
+operation_count=10000
 create_validation_parameters=validation_params.csv|100
+
+ldbc.snb.interactive.updates_dir=test-data/update_streams/
+ldbc.snb.interactive.parameters_dir=test-data/substitution_parameters/
+ldbc.snb.interactive.short_read_dissipation=0.2
+ldbc.snb.interactive.update_interleave=895969
 
 ## frequency of read queries (number of update queries per one read query)
 ldbc.snb.interactive.LdbcQuery1_freq=26

--- a/postgres/driver/validate.properties
+++ b/postgres/driver/validate.properties
@@ -23,13 +23,16 @@ ignore_scheduled_start_times=false
 
 workload=com.ldbc.driver.workloads.ldbc.snb.interactive.LdbcSnbInteractiveWorkload
 db=com.ldbc.impls.workloads.ldbc.snb.postgres.interactive.PostgresInteractiveDb
+
 operation_count=10000
 
 validate_workload=true
 validate_database=validation_params.csv
+
 ldbc.snb.interactive.parameters_dir=test-data/substitution_parameters/
 ldbc.snb.interactive.short_read_dissipation=0.2
-ldbc.snb.interactive.update_interleave=49274
+
+ldbc.snb.interactive.update_interleave=895969
 
 ldbc.snb.interactive.LdbcQuery1_freq=1
 ldbc.snb.interactive.LdbcQuery2_freq=1

--- a/query-frequencies/sf1.properties
+++ b/query-frequencies/sf1.properties
@@ -1,0 +1,16 @@
+ldbc.snb.interactive.update_interleave=4477
+
+ldbc.snb.interactive.LdbcQuery1_freq=26
+ldbc.snb.interactive.LdbcQuery2_freq=37
+ldbc.snb.interactive.LdbcQuery3_freq=69
+ldbc.snb.interactive.LdbcQuery4_freq=36
+ldbc.snb.interactive.LdbcQuery5_freq=57
+ldbc.snb.interactive.LdbcQuery6_freq=129
+ldbc.snb.interactive.LdbcQuery7_freq=87
+ldbc.snb.interactive.LdbcQuery8_freq=45
+ldbc.snb.interactive.LdbcQuery9_freq=157
+ldbc.snb.interactive.LdbcQuery10_freq=30
+ldbc.snb.interactive.LdbcQuery11_freq=16
+ldbc.snb.interactive.LdbcQuery12_freq=44
+ldbc.snb.interactive.LdbcQuery13_freq=19
+ldbc.snb.interactive.LdbcQuery14_freq=49

--- a/sf-properties/sf1.properties
+++ b/sf-properties/sf1.properties
@@ -1,0 +1,16 @@
+ldbc.snb.interactive.update_interleave=4477
+
+ldbc.snb.interactive.LdbcQuery1_freq=26
+ldbc.snb.interactive.LdbcQuery2_freq=37
+ldbc.snb.interactive.LdbcQuery3_freq=69
+ldbc.snb.interactive.LdbcQuery4_freq=36
+ldbc.snb.interactive.LdbcQuery5_freq=57
+ldbc.snb.interactive.LdbcQuery6_freq=129
+ldbc.snb.interactive.LdbcQuery7_freq=87
+ldbc.snb.interactive.LdbcQuery8_freq=45
+ldbc.snb.interactive.LdbcQuery9_freq=157
+ldbc.snb.interactive.LdbcQuery10_freq=30
+ldbc.snb.interactive.LdbcQuery11_freq=16
+ldbc.snb.interactive.LdbcQuery12_freq=44
+ldbc.snb.interactive.LdbcQuery13_freq=19
+ldbc.snb.interactive.LdbcQuery14_freq=49

--- a/sf-properties/sf10.properties
+++ b/sf-properties/sf10.properties
@@ -1,0 +1,16 @@
+ldbc.snb.interactive.update_interleave=466
+
+ldbc.snb.interactive.LdbcQuery1_freq=26
+ldbc.snb.interactive.LdbcQuery2_freq=37
+ldbc.snb.interactive.LdbcQuery3_freq=92
+ldbc.snb.interactive.LdbcQuery4_freq=36
+ldbc.snb.interactive.LdbcQuery5_freq=66
+ldbc.snb.interactive.LdbcQuery6_freq=236
+ldbc.snb.interactive.LdbcQuery7_freq=54
+ldbc.snb.interactive.LdbcQuery8_freq=15
+ldbc.snb.interactive.LdbcQuery9_freq=287
+ldbc.snb.interactive.LdbcQuery10_freq=35
+ldbc.snb.interactive.LdbcQuery11_freq=19
+ldbc.snb.interactive.LdbcQuery12_freq=44
+ldbc.snb.interactive.LdbcQuery13_freq=19
+ldbc.snb.interactive.LdbcQuery14_freq=49

--- a/sf-properties/sf100.properties
+++ b/sf-properties/sf100.properties
@@ -1,0 +1,16 @@
+ldbc.snb.interactive.update_interleave=48
+
+ldbc.snb.interactive.LdbcQuery1_freq=26
+ldbc.snb.interactive.LdbcQuery2_freq=37
+ldbc.snb.interactive.LdbcQuery3_freq=123
+ldbc.snb.interactive.LdbcQuery4_freq=36
+ldbc.snb.interactive.LdbcQuery5_freq=78
+ldbc.snb.interactive.LdbcQuery6_freq=434
+ldbc.snb.interactive.LdbcQuery7_freq=38
+ldbc.snb.interactive.LdbcQuery8_freq=5
+ldbc.snb.interactive.LdbcQuery9_freq=527
+ldbc.snb.interactive.LdbcQuery10_freq=40
+ldbc.snb.interactive.LdbcQuery11_freq=22
+ldbc.snb.interactive.LdbcQuery12_freq=44
+ldbc.snb.interactive.LdbcQuery13_freq=19
+ldbc.snb.interactive.LdbcQuery14_freq=49

--- a/sf-properties/sf1000.properties
+++ b/sf-properties/sf1000.properties
@@ -1,0 +1,16 @@
+ldbc.snb.interactive.update_interleave=5
+
+ldbc.snb.interactive.LdbcQuery1_freq=26
+ldbc.snb.interactive.LdbcQuery2_freq=37
+ldbc.snb.interactive.LdbcQuery3_freq=165
+ldbc.snb.interactive.LdbcQuery4_freq=36
+ldbc.snb.interactive.LdbcQuery5_freq=91
+ldbc.snb.interactive.LdbcQuery6_freq=796
+ldbc.snb.interactive.LdbcQuery7_freq=25
+ldbc.snb.interactive.LdbcQuery8_freq=1
+ldbc.snb.interactive.LdbcQuery9_freq=967
+ldbc.snb.interactive.LdbcQuery10_freq=47
+ldbc.snb.interactive.LdbcQuery11_freq=26
+ldbc.snb.interactive.LdbcQuery12_freq=44
+ldbc.snb.interactive.LdbcQuery13_freq=19
+ldbc.snb.interactive.LdbcQuery14_freq=49

--- a/sf-properties/sf3.properties
+++ b/sf-properties/sf3.properties
@@ -1,0 +1,16 @@
+ldbc.snb.interactive.update_interleave=1542
+
+ldbc.snb.interactive.LdbcQuery1_freq=26
+ldbc.snb.interactive.LdbcQuery2_freq=37
+ldbc.snb.interactive.LdbcQuery3_freq=79
+ldbc.snb.interactive.LdbcQuery4_freq=36
+ldbc.snb.interactive.LdbcQuery5_freq=61
+ldbc.snb.interactive.LdbcQuery6_freq=172
+ldbc.snb.interactive.LdbcQuery7_freq=72
+ldbc.snb.interactive.LdbcQuery8_freq=27
+ldbc.snb.interactive.LdbcQuery9_freq=209
+ldbc.snb.interactive.LdbcQuery10_freq=32
+ldbc.snb.interactive.LdbcQuery11_freq=17
+ldbc.snb.interactive.LdbcQuery12_freq=44
+ldbc.snb.interactive.LdbcQuery13_freq=19
+ldbc.snb.interactive.LdbcQuery14_freq=49

--- a/sf-properties/sf30.properties
+++ b/sf-properties/sf30.properties
@@ -1,0 +1,16 @@
+ldbc.snb.interactive.update_interleave=156
+
+ldbc.snb.interactive.LdbcQuery1_freq=26
+ldbc.snb.interactive.LdbcQuery2_freq=37
+ldbc.snb.interactive.LdbcQuery3_freq=106
+ldbc.snb.interactive.LdbcQuery4_freq=36
+ldbc.snb.interactive.LdbcQuery5_freq=72
+ldbc.snb.interactive.LdbcQuery6_freq=316
+ldbc.snb.interactive.LdbcQuery7_freq=48
+ldbc.snb.interactive.LdbcQuery8_freq=9
+ldbc.snb.interactive.LdbcQuery9_freq=384
+ldbc.snb.interactive.LdbcQuery10_freq=37
+ldbc.snb.interactive.LdbcQuery11_freq=20
+ldbc.snb.interactive.LdbcQuery12_freq=44
+ldbc.snb.interactive.LdbcQuery13_freq=19
+ldbc.snb.interactive.LdbcQuery14_freq=49

--- a/sf-properties/sf300.properties
+++ b/sf-properties/sf300.properties
@@ -1,0 +1,16 @@
+ldbc.snb.interactive.update_interleave=17
+
+ldbc.snb.interactive.LdbcQuery1_freq=26
+ldbc.snb.interactive.LdbcQuery2_freq=37
+ldbc.snb.interactive.LdbcQuery3_freq=142
+ldbc.snb.interactive.LdbcQuery4_freq=36
+ldbc.snb.interactive.LdbcQuery5_freq=84
+ldbc.snb.interactive.LdbcQuery6_freq=580
+ldbc.snb.interactive.LdbcQuery7_freq=32
+ldbc.snb.interactive.LdbcQuery8_freq=3
+ldbc.snb.interactive.LdbcQuery9_freq=705
+ldbc.snb.interactive.LdbcQuery10_freq=44
+ldbc.snb.interactive.LdbcQuery11_freq=24
+ldbc.snb.interactive.LdbcQuery12_freq=44
+ldbc.snb.interactive.LdbcQuery13_freq=19
+ldbc.snb.interactive.LdbcQuery14_freq=49


### PR DESCRIPTION
To this, the READMEs (both the main one and the project-level ones)
received a warning and the default values in the .properties files were
changed. Also, the `sf-properties` directory contains the correct values
for SFs 1..1000

Fixes #203 