### PR TITLE
Load comments table as-is and use SQL to create messages table

### DIFF
--- a/postgres/ddl/schema.sql
+++ b/postgres/ddl/schema.sql
@@ -17,28 +17,55 @@ drop table if exists forum;
 drop table if exists person;
 drop table if exists place;
 
-create table message (
-    /*
-     * m_ps_ denotes field specific to posts
-     * m_c_  denotes field specific to comments
-     * other m_ fields are common to posts and messages
-     * Note: to distinguish between "post" and "comment" records:
-     *   - m_c_replyof IS NULL for all "post" records
-     *   - m_c_replyof IS NOT NULL for all "comment" records
-     */
+create table post (
     m_messageid bigint not null,
     m_ps_imagefile varchar,
-    m_creationdate timestamp with time zone not null,
+    m_creationdate timestamp without time zone not null,
     m_locationip varchar not null,
     m_browserused varchar not null,
     m_ps_language varchar,
     m_content text,
     m_length int not null,
     m_creatorid bigint not null,
-    m_locationid bigint not null,
-    m_ps_forumid bigint, -- null for comments
-    m_c_replyof bigint -- null for posts
+    m_ps_forumid bigint,
+    m_locationid bigint not null
 );
+
+create table comment (
+    m_messageid bigint not null,
+    m_creationdate timestamp without time zone not null,
+    m_locationip varchar not null,
+    m_browserused varchar not null,
+    m_content text,
+    m_length int not null,
+    m_creatorid bigint not null,
+    m_locationid bigint not null,
+    m_replyof_post bigint,
+    m_replyof_comment bigint
+);
+
+-- create table message (
+--     /*
+--      * m_ps_ denotes field specific to posts
+--      * m_c_  denotes field specific to comments
+--      * other m_ fields are common to posts and messages
+--      * Note: to distinguish between "post" and "comment" records:
+--      *   - m_c_replyof IS NULL for all "post" records
+--      *   - m_c_replyof IS NOT NULL for all "comment" records
+--      */
+--     m_messageid bigint not null,
+--     m_ps_imagefile varchar,
+--     m_creationdate timestamp with time zone not null,
+--     m_locationip varchar not null,
+--     m_browserused varchar not null,
+--     m_ps_language varchar,
+--     m_content text,
+--     m_length int not null,
+--     m_creatorid bigint not null,
+--     m_locationid bigint not null,
+--     m_ps_forumid bigint, -- null for comments
+--     m_c_replyof bigint -- null for posts
+-- );
 
 create table forum (
    f_forumid bigint not null,

--- a/postgres/ddl/snb-load.sql
+++ b/postgres/ddl/snb-load.sql
@@ -49,11 +49,25 @@ COPY tagclass FROM '/data/static/tagclass_0_0.csv' WITH DELIMITER '|' CSV HEADER
 -- Populate tag table
 COPY tag FROM '/data/static/tag_0_0.csv' WITH DELIMITER '|' CSV HEADER;
 
+CREATE TABLE country AS
+    SELECT city.pl_placeid AS ctry_city, ctry.pl_name AS ctry_name
+    FROM place city, place ctry
+    WHERE city.pl_containerplaceid = ctry.pl_placeid
+      AND ctry.pl_type = 'country';
 
--- PROBLEMATIC
+-- Populate posts and comments tables, union them into message
+COPY post FROM '/data/dynamic/post_0_0.csv' WITH (DELIMITER '|', HEADER, FORMAT csv);
+COPY comment FROM '/data/dynamic/comment_0_0.csv' WITH (DELIMITER '|', HEADER, FORMAT csv);
 
--- Populate message table
-COPY message (m_messageid, m_ps_imagefile, m_creationdate, m_locationip, m_browserused, m_ps_language, m_content, m_length, m_creatorid, m_ps_forumid, m_locationid) FROM '/data/dynamic/post_0_0.csv' WITH (DELIMITER '|', HEADER, FORMAT csv);
-COPY message FROM '/data/dynamic/comment_0_0-postgres.csv' WITH (DELIMITER '|', HEADER, FORMAT csv);
+-- Note: to distinguish between "post" and "comment" records:
+--   - m_c_replyof IS NULL for all "post" records
+--   - m_c_replyof IS NOT NULL for all "comment" records
+CREATE TABLE message AS
+    SELECT m_messageid, m_ps_imagefile, m_creationdate, m_locationip, m_browserused, m_ps_language, m_content, m_length, m_creatorid, m_locationid, m_ps_forumid, NULL AS m_c_replyof
+    FROM post
+    UNION ALL
+    SELECT m_messageid, NULL, m_creationdate, m_locationip, m_browserused, NULL, m_content, m_length, m_creatorid, m_locationid, NULl, coalesce(m_replyof_post, m_replyof_comment)
+    FROM comment;
 
-CREATE view country AS SELECT city.pl_placeid AS ctry_city, ctry.pl_name AS ctry_name FROM place city, place ctry WHERE city.pl_containerplaceid = ctry.pl_placeid AND ctry.pl_type = 'country';
+DROP TABLE post;
+DROP TABLE comment;

--- a/postgres/scripts/load.sh
+++ b/postgres/scripts/load.sh
@@ -13,17 +13,4 @@ if [ ! -d "${POSTGRES_CSV_DIR}" ]; then
     exit 1
 fi
 
-POSTGRES_FORCE_REGENERATE=${POSTGRES_FORCE_REGENERATE:-no}
-
-# we regenerate PostgreSQL-specific CSV files for comments, if either
-#  - it doesn't exist
-#  - the source CSV is newer
-#  - we are forced to do so by environment variable POSTGRES_FORCE_REGENERATE=yes
-
-if [ ! -f ${POSTGRES_CSV_DIR}/dynamic/comment_0_0-postgres.csv -o ${POSTGRES_CSV_DIR}/dynamic/comment_0_0.csv -nt ${POSTGRES_CSV_DIR}/dynamic/comment_0_0-postgres.csv -o "${POSTGRES_FORCE_REGENERATE}x" = "yesx" ]; then
-    cat ${POSTGRES_CSV_DIR}/dynamic/comment_0_0.csv | \
-        awk -F '|' '{print $1"||"$2"|"$3"|"$4"||"$5"|"$6"|"$7"|"$8"||"$9 $10}' > \
-        ${POSTGRES_CSV_DIR}/dynamic/comment_0_0-postgres.csv
-fi
-
 python3 load.py


### PR DESCRIPTION
Rather than relying on CLI tools such as AWK as before
(when both `comment_*.csv` and `post_*.csv` were directly loaded to the same
table).