### PR TITLE
Fix default configuration of 'ignore_scheduled_start_times' values

### DIFF
--- a/cypher/driver/benchmark.properties
+++ b/cypher/driver/benchmark.properties
@@ -17,7 +17,7 @@ peer_identifiers=
 workload_statistics=false
 spinner_wait_duration=1
 help=false
-ignore_scheduled_start_times=true
+ignore_scheduled_start_times=false
 
 workload=com.ldbc.driver.workloads.ldbc.snb.interactive.LdbcSnbInteractiveWorkload
 db=com.ldbc.impls.workloads.ldbc.snb.cypher.interactive.CypherInteractiveDb

--- a/cypher/driver/create-validation-parameters.properties
+++ b/cypher/driver/create-validation-parameters.properties
@@ -17,7 +17,7 @@ peer_identifiers=
 workload_statistics=false
 spinner_wait_duration=0
 help=false
-ignore_scheduled_start_times=false
+ignore_scheduled_start_times=true
 
 workload=com.ldbc.driver.workloads.ldbc.snb.interactive.LdbcSnbInteractiveWorkload
 db=com.ldbc.impls.workloads.ldbc.snb.cypher.interactive.CypherInteractiveDb

--- a/cypher/driver/validate.properties
+++ b/cypher/driver/validate.properties
@@ -17,7 +17,7 @@ peer_identifiers=
 workload_statistics=false
 spinner_wait_duration=0
 help=false
-ignore_scheduled_start_times=false
+ignore_scheduled_start_times=true
 
 workload=com.ldbc.driver.workloads.ldbc.snb.interactive.LdbcSnbInteractiveWorkload
 db=com.ldbc.impls.workloads.ldbc.snb.cypher.interactive.CypherInteractiveDb

--- a/duckdb/driver/benchmark.properties
+++ b/duckdb/driver/benchmark.properties
@@ -14,7 +14,7 @@ peer_identifiers=
 workload_statistics=false
 spinner_wait_duration=1
 help=false
-ignore_scheduled_start_times=true
+ignore_scheduled_start_times=false
 
 workload=com.ldbc.driver.workloads.ldbc.snb.interactive.LdbcSnbInteractiveWorkload
 db=com.ldbc.impls.workloads.ldbc.snb.duckdb.interactive.DuckDbInteractiveDb

--- a/duckdb/driver/create-validation-parameters.properties
+++ b/duckdb/driver/create-validation-parameters.properties
@@ -14,7 +14,7 @@ peer_identifiers=
 workload_statistics=false
 spinner_wait_duration=0
 help=false
-ignore_scheduled_start_times=false
+ignore_scheduled_start_times=true
 
 workload=com.ldbc.driver.workloads.ldbc.snb.interactive.LdbcSnbInteractiveWorkload
 db=com.ldbc.impls.workloads.ldbc.snb.duckdb.interactive.

--- a/duckdb/driver/validate.properties
+++ b/duckdb/driver/validate.properties
@@ -3,6 +3,7 @@ queryDir=queries
 printQueryNames=true
 printQueryStrings=false
 printQueryResults=false
+
 status=1
 thread_count=1
 name=LDBC-SNB

--- a/duckdb/driver/validate.properties
+++ b/duckdb/driver/validate.properties
@@ -13,7 +13,7 @@ peer_identifiers=
 workload_statistics=false
 spinner_wait_duration=0
 help=false
-ignore_scheduled_start_times=false
+ignore_scheduled_start_times=true
 
 workload=com.ldbc.driver.workloads.ldbc.snb.interactive.LdbcSnbInteractiveWorkload
 db=com.ldbc.impls.workloads.ldbc.snb.duckdb.interactive.DuckDbInteractiveDb

--- a/postgres/driver/benchmark.properties
+++ b/postgres/driver/benchmark.properties
@@ -19,7 +19,7 @@ peer_identifiers=
 workload_statistics=false
 spinner_wait_duration=1
 help=false
-ignore_scheduled_start_times=true
+ignore_scheduled_start_times=false
 
 workload=com.ldbc.driver.workloads.ldbc.snb.interactive.LdbcSnbInteractiveWorkload
 db=com.ldbc.impls.workloads.ldbc.snb.postgres.interactive.PostgresInteractiveDb

--- a/postgres/driver/create-validation-parameters.properties
+++ b/postgres/driver/create-validation-parameters.properties
@@ -19,7 +19,7 @@ peer_identifiers=
 workload_statistics=false
 spinner_wait_duration=0
 help=false
-ignore_scheduled_start_times=false
+ignore_scheduled_start_times=true
 
 workload=com.ldbc.driver.workloads.ldbc.snb.interactive.LdbcSnbInteractiveWorkload
 db=com.ldbc.impls.workloads.ldbc.snb.postgres.interactive.PostgresInteractiveDb

--- a/postgres/driver/validate.properties
+++ b/postgres/driver/validate.properties
@@ -19,7 +19,7 @@ peer_identifiers=
 workload_statistics=false
 spinner_wait_duration=0
 help=false
-ignore_scheduled_start_times=false
+ignore_scheduled_start_times=true
 
 workload=com.ldbc.driver.workloads.ldbc.snb.interactive.LdbcSnbInteractiveWorkload
 db=com.ldbc.impls.workloads.ldbc.snb.postgres.interactive.PostgresInteractiveDb


### PR DESCRIPTION
The default values of the `ignore_scheduled_start_times` configuration properties were set exactly to the opposite values of what they should have been. For proof, see the [FDR of the 2020 audit](https://ldbcouncil.org/benchmarks/snb/LDBC_SNB_I_20200726_SF30-100-300_tugraph.pdf)

Fixes #213.